### PR TITLE
Custom Annotation으로 인증 정보 가져오기

### DIFF
--- a/src/main/java/com/woong/mintchoco/adapter/UserAdapter.java
+++ b/src/main/java/com/woong/mintchoco/adapter/UserAdapter.java
@@ -1,0 +1,17 @@
+package com.woong.mintchoco.adapter;
+
+import com.woong.mintchoco.domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserAdapter extends org.springframework.security.core.userdetails.User {
+
+    private User user;
+
+    public UserAdapter(User user) {
+        super(user.getUserId(), user.getPassword(), user.getAuthorities());
+        this.user = user;
+    }
+}

--- a/src/main/java/com/woong/mintchoco/annotation/AuthUser.java
+++ b/src/main/java/com/woong/mintchoco/annotation/AuthUser.java
@@ -1,0 +1,13 @@
+package com.woong.mintchoco.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+public @interface AuthUser {
+}

--- a/src/main/java/com/woong/mintchoco/domain/AttachFile.java
+++ b/src/main/java/com/woong/mintchoco/domain/AttachFile.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class AttachFile extends BaseEntity implements Serializable {
 
+    @Serial
+    private static final long serialVersionUID = 8478133987894974510L;
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/woong/mintchoco/domain/Store.java
+++ b/src/main/java/com/woong/mintchoco/domain/Store.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,6 +23,9 @@ import lombok.ToString;
 @NoArgsConstructor
 public class Store extends BaseEntity implements Serializable {
 
+    @Serial
+    private static final long serialVersionUID = 4304254191931937770L;
+    
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/woong/mintchoco/domain/User.java
+++ b/src/main/java/com/woong/mintchoco/domain/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import java.io.Serial;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
@@ -19,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.ToString.Exclude;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -30,6 +32,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 @ToString
 @Builder
 public class User extends UserBaseEntity implements UserDetails {
+
+    @Serial
+    private static final long serialVersionUID = -2246490400695224910L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -46,11 +52,14 @@ public class User extends UserBaseEntity implements UserDetails {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "file_id")
+    @Setter
+    @Exclude
     private AttachFile profileImage;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
     @Setter
+    @Exclude
     private Store store;
 
     @Enumerated(EnumType.STRING)
@@ -109,5 +118,9 @@ public class User extends UserBaseEntity implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public User getUser() {
+        return this;
     }
 }

--- a/src/main/java/com/woong/mintchoco/repository/store/StoreRepositoryImpl.java
+++ b/src/main/java/com/woong/mintchoco/repository/store/StoreRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.querydsl.jpa.impl.JPAUpdateClause;
 import com.woong.mintchoco.domain.QStore;
 import com.woong.mintchoco.vo.StoreVO;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -30,9 +31,10 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                         .update(qStore)
                         .set(
                                 List.of(qStore.name, qStore.intro, qStore.zipCode, qStore.address, qStore.tel,
-                                        qStore.closedDays),
+                                        qStore.closedDays, qStore.updatedAt),
                                 List.of(storeVO.getName(), storeVO.getIntro(), storeVO.getZipCode(),
-                                        storeVO.getAddress(), storeVO.getTel(), storeVO.getClosedDays())
+                                        storeVO.getAddress(), storeVO.getTel(), storeVO.getClosedDays(),
+                                        LocalDateTime.now())
                         )
                         .where(qStore.id.eq(id));
 

--- a/src/main/java/com/woong/mintchoco/repository/user/UserRepositoryImpl.java
+++ b/src/main/java/com/woong/mintchoco/repository/user/UserRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woong.mintchoco.domain.QAttachFile;
 import com.woong.mintchoco.domain.QUser;
 import com.woong.mintchoco.vo.UserVO;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -27,16 +28,18 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         if (userVO.getProfileImage() == null) {
             jpaQueryFactory
                     .update(qUser)
-                    .set(List.of(qUser.name, qUser.email, qUser.businessNumber, qUser.tel),
-                            List.of(userVO.getName(), userVO.getEmail(), userVO.getBusinessNumber(), userVO.getTel()))
+                    .set(List.of(qUser.name, qUser.email, qUser.businessNumber, qUser.tel, qUser.updatedAt),
+                            List.of(userVO.getName(), userVO.getEmail(), userVO.getBusinessNumber(), userVO.getTel(),
+                                    LocalDateTime.now()))
                     .where(qUser.userId.eq(userVO.getUserId()))
                     .execute();
         } else {
             jpaQueryFactory
                     .update(qUser)
-                    .set(List.of(qUser.name, qUser.email, qUser.businessNumber, qUser.tel, qUser.profileImage),
+                    .set(List.of(qUser.name, qUser.email, qUser.businessNumber, qUser.tel, qUser.profileImage,
+                                    qUser.updatedAt),
                             List.of(userVO.getName(), userVO.getEmail(), userVO.getBusinessNumber(), userVO.getTel(),
-                                    userVO.getProfileImage()))
+                                    userVO.getProfileImage(), LocalDateTime.now()))
                     .where(qUser.userId.eq(userVO.getUserId()))
                     .execute();
         }
@@ -54,6 +57,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         jpaQueryFactory
                 .update(qUser)
                 .set(qUser.profileImage, userVO.getProfileImage())
+                .set(qUser.updatedAt, LocalDateTime.now())
                 .where(qUser.userId.eq(userVO.getUserId()))
                 .execute();
         jpaQueryFactory
@@ -72,6 +76,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         jpaQueryFactory
                 .update(qUser)
                 .set(qUser.userPwd, userVO.getNewPwd())
+                .set(qUser.updatedAt, LocalDateTime.now())
                 .where(qUser.userId.eq(userVO.getUserId()))
                 .execute();
     }

--- a/src/main/java/com/woong/mintchoco/security/provider/AdminAuthenticatorProvider.java
+++ b/src/main/java/com/woong/mintchoco/security/provider/AdminAuthenticatorProvider.java
@@ -27,7 +27,7 @@ public class AdminAuthenticatorProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
         String password = (String) authentication.getCredentials();
-        User user = userService.loadUserByUsername(username);
+        User user = userService.loadUserByUsername(username).getUser();
         String dbPassword = user.getPassword();
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/woong/mintchoco/security/provider/OwnerAuthenticatorProvider.java
+++ b/src/main/java/com/woong/mintchoco/security/provider/OwnerAuthenticatorProvider.java
@@ -27,7 +27,7 @@ public class OwnerAuthenticatorProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
         String password = (String) authentication.getCredentials();
-        User user = userService.loadUserByUsername(username);
+        User user = userService.loadUserByUsername(username).getUser();
         String dbPassword = user.getPassword();
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/woong/mintchoco/security/provider/UserAuthenticationProvider.java
+++ b/src/main/java/com/woong/mintchoco/security/provider/UserAuthenticationProvider.java
@@ -27,7 +27,7 @@ public class UserAuthenticationProvider implements AuthenticationProvider {
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
         String password = (String) authentication.getCredentials();
-        User user = userService.loadUserByUsername(username);
+        User user = userService.loadUserByUsername(username).getUser();
         String dbPassword = user.getPassword();
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 

--- a/src/main/java/com/woong/mintchoco/service/UserService.java
+++ b/src/main/java/com/woong/mintchoco/service/UserService.java
@@ -1,5 +1,6 @@
 package com.woong.mintchoco.service;
 
+import com.woong.mintchoco.adapter.UserAdapter;
 import com.woong.mintchoco.domain.User;
 import com.woong.mintchoco.exception.ErrorCode;
 import com.woong.mintchoco.exception.password.DuplicatePasswordException;
@@ -8,7 +9,6 @@ import com.woong.mintchoco.repository.user.UserRepository;
 import com.woong.mintchoco.vo.UserVO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -48,31 +48,30 @@ public class UserService implements UserDetailsService {
 
 
     @Override
-    public User loadUserByUsername(String username) throws UsernameNotFoundException {
+    public UserAdapter loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUserId(username);
         if (user == null) {
             throw new UsernameNotFoundException("등록된 사용자가 아닙니다.");
         }
-        return user;
+        return new UserAdapter(user);
     }
 
     /**
      * 비밀번호를 변경한다. 입력받은 비밀번호와 DB에 저장된 비밀번호가 일치하지 않으면 InvalidPasswordException 발생 입력받은 비밀번호가 사용중인 비밀번호와 일치하면
      * DuplicatePasswordException 발생
      *
-     * @param authentication 인증 정보
-     * @param userVO         유저 정보
+     * @param user   인증 정보
+     * @param userVO 유저 정보
      */
-    public void changePassword(Authentication authentication, UserVO userVO) {
+    public void changePassword(User user, UserVO userVO) {
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-        User user = (User) authentication.getPrincipal();
         if (!passwordEncoder.matches(userVO.getUserPwd(), user.getPassword())) {
             throw new InvalidPasswordException(ErrorCode.INVALID_PASSWORD);
         }
         if (passwordEncoder.matches(userVO.getNewPwd(), user.getPassword())) {
             throw new DuplicatePasswordException(ErrorCode.DUPLICATE_PASSWORD);
         }
-        userVO.setUserId(authentication.getName());
+        userVO.setUserId(user.getUserId());
         userVO.setNewPwd(passwordEncoder.encode(userVO.getNewPwd()));
         userRepository.updateUserPwd(userVO);
     }

--- a/src/main/resources/static/js/owner/profile/ownerInfo.js
+++ b/src/main/resources/static/js/owner/profile/ownerInfo.js
@@ -34,7 +34,8 @@ $(function () {
                 method: "GET"
             })
                 .done(() => {
-                    $("#profile").attr("src", "/img/default-user.svg")
+                    $("#profile").attr("src", "/img/default-user.svg");
+                    $("#cardProfileImage").attr("src", "/img/default-user.svg");
                     $("#imageDelete").remove();
                 })
                 .fail(() => {
@@ -150,10 +151,12 @@ function readURL(input) {
         const reader = new FileReader();
         reader.onload = function (e) {
             $("#profile").attr("src", e.target.result);
+            $("#cardProfileImage").attr("src", e.target.result);
         };
         reader.readAsDataURL(input.files[0]);
     } else {
         $("#profile").attr("src", "");
+        $("#cardProfileImage").attr("src", "");
     }
 }
 

--- a/src/main/resources/templates/views/owner/profile/ownerInfo.html
+++ b/src/main/resources/templates/views/owner/profile/ownerInfo.html
@@ -26,8 +26,8 @@
                     <div class="card">
                         <div class="card-body profile-card pt-4 d-flex flex-column align-items-center">
 
-                            <img th:src="${userVO.profileImage != null} ? ${userVO.profileImage.savedPath} : '/img/profile-img.jpg'"
-                                 alt="Profile" class="rounded-circle">
+                            <img th:src="${userVO.profileImage != null} ? ${userVO.profileImage.savedPath} : '/img/default-user.svg'"
+                                 alt="Profile" class="rounded-circle" id="cardProfileImage">
                             <h2 th:text="${userVO.name}"></h2>
                             <!--                            <h3>Web Designer</h3>-->
                             <div class="social-links mt-2">


### PR DESCRIPTION
Custom Annotation `@AuthUser`를 이용하여 인증정보를 쉽게 가져올 수 있다.
기존에는 Authentication에서 `getName()`을 통해 유저의 아이디를 가져와 DB에서 조회를 해야하는데, 
`@AuthUser`를 이용하면 이 과정이 필요 없어 불필요한 쿼리의 사용을 줄일 수 있었다.

QueryDsl에서 업데이트를 하면 Auditing이 동작하지 않는다. 우선은, 직접 추가해줬는데 나중에 다른 방법을 모색해보자.